### PR TITLE
Pin actions to major tags and group Go module updates monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,8 @@
-# Keeps the SHA-pinned actions and the Go module graph current. govulncheck
-# is a blocking CI gate, so a CVE in a dependency turns main red; these PRs
-# are how it turns green again without a manual bump.
+# Keeps the actions and the Go module graph current. Actions are pinned to
+# major tags, so Dependabot only opens a PR when a major version lands.
+# Go modules are grouped into one monthly PR; govulncheck is a blocking CI
+# gate, so a CVE still shows up on main immediately, and that PR is how it
+# turns green again.
 version: 2
 updates:
   - package-ecosystem: github-actions
@@ -11,10 +13,8 @@ updates:
   - package-ecosystem: gomod
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
     labels: [dependencies]
     groups:
-      aws-sdk:
-        patterns: ["github.com/aws/*"]
-      opentelemetry:
-        patterns: ["go.opentelemetry.io/*"]
+      go-modules:
+        patterns: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,13 +55,13 @@ jobs:
     runs-on: namespace-profile-linux-${{ matrix.arch }}
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
           cache: false
       # Go module + build cache on a Namespace cache volume (see the note above).
-      - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1
+      - uses: namespacelabs/nscloud-cache-action@v1
         # Non-fatal on purpose: the action hard-errors when the runner profile
         # has Caching disabled, and a missing cache is a slow build, not a
         # wrong one.
@@ -83,7 +83,7 @@ jobs:
       - name: go test -race
         run: go test -race ./...
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@db9de0fc1a667e1a49d2291a1a042dff081d78f6 # v9
+        uses: golangci/golangci-lint-action@v9
         with:
           # Pinned: "latest" breaks CI on linter releases with zero code
           # change. Bump deliberately.
@@ -113,8 +113,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
       - name: Prepare
@@ -130,7 +130,7 @@ jobs:
       - name: go test -race
         run: go test -race ./...
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@db9de0fc1a667e1a49d2291a1a042dff081d78f6 # v9
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.13
       - name: govulncheck
@@ -171,13 +171,13 @@ jobs:
     runs-on: namespace-profile-linux-amd64
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
           cache: false
       # Go module + build cache on a Namespace cache volume (see the note above).
-      - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1
+      - uses: namespacelabs/nscloud-cache-action@v1
         # Non-fatal on purpose: the action hard-errors when the runner profile
         # has Caching disabled, and a missing cache is a slow build, not a
         # wrong one. Enable Caching on the profile to get the volume back
@@ -223,13 +223,13 @@ jobs:
     runs-on: namespace-profile-linux-amd64
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
           cache: false
       # Go module + build cache on a Namespace cache volume (see the note above).
-      - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1
+      - uses: namespacelabs/nscloud-cache-action@v1
         # Non-fatal on purpose: the action hard-errors when the runner profile
         # has Caching disabled, and a missing cache is a slow build, not a
         # wrong one. Enable Caching on the profile to get the volume back
@@ -264,13 +264,13 @@ jobs:
     runs-on: namespace-profile-linux-amd64
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
           cache: false
       # Go module + build cache on a Namespace cache volume (see the note above).
-      - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1
+      - uses: namespacelabs/nscloud-cache-action@v1
         continue-on-error: true
         with:
           cache: go

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,13 +38,13 @@ jobs:
     environment: release
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
           cache: false
       # Go module + build cache on a Namespace cache volume (see ci.yml).
-      - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1
+      - uses: namespacelabs/nscloud-cache-action@v1
         # Non-fatal on purpose: the action hard-errors when the runner profile
         # has Caching disabled, and a missing cache is a slow build, not a
         # wrong one. Enable Caching on the profile to get the volume back
@@ -118,7 +118,7 @@ jobs:
           echo "digest=$digest" >> "$GITHUB_OUTPUT"
 
       - name: Sign the image (keyless)
-        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        uses: sigstore/cosign-installer@v4
       - name: Cosign sign + verify
         run: |
           digest='${{ steps.build.outputs.digest }}'
@@ -136,7 +136,7 @@ jobs:
       #     --repo emirb/kernelbuild-buildkit
       # No key material, no cosign install, no certificate flags for the user.
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@43d14bc2b83dec42d39ecae14e916627a18bb661 # v3
+        uses: actions/attest-build-provenance@v3
         with:
           subject-name: ${{ env.IMAGE }}
           subject-digest: ${{ steps.build.outputs.digest }}


### PR DESCRIPTION
Major tags instead of commit SHAs: fewer Dependabot pull requests, at the
cost of trusting each action's maintainers to move their major tag
responsibly. Go module bumps arrive as one grouped PR a month; govulncheck
in CI still flags a vulnerable dependency on main the day it is published.
