### PR TITLE
CI: run the #syntax= e2e on every change and gate releases on a booted kernel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,24 +137,30 @@ jobs:
         run: govulncheck ./...
 
   # The one status check the main ruleset requires. Same-repo changes run
-  # `unit`, fork PRs run `unit-fork`; this job passes when whichever of the
-  # two applied succeeded, so both paths can satisfy a single required check.
+  # `unit` and `e2e`, fork PRs run `unit-fork` only; this job passes when
+  # whichever path applied succeeded in full, so both can satisfy a single
+  # required check.
   ci:
     name: ci
     if: always()
-    needs: [unit, unit-fork]
+    needs: [unit, unit-fork, e2e]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - env:
           UNIT: ${{ needs.unit.result }}
           FORK: ${{ needs.unit-fork.result }}
+          E2E: ${{ needs.e2e.result }}
         run: |
-          echo "unit=$UNIT unit-fork=$FORK"
-          case "$UNIT $FORK" in
+          echo "unit=$UNIT unit-fork=$FORK e2e=$E2E"
+          case "$UNIT $FORK $E2E" in
             *failure*|*cancelled*) echo "::error::a required job failed"; exit 1 ;;
           esac
-          [ "$UNIT" = success ] || [ "$FORK" = success ] || { echo "::error::no unit job ran"; exit 1; }
+          if [ "$UNIT" = success ]; then
+            [ "$E2E" = success ] || { echo "::error::e2e did not run for a same-repo change"; exit 1; }
+          else
+            [ "$FORK" = success ] || { echo "::error::no unit job ran"; exit 1; }
+          fi
 
   # End-to-end against a live buildkitd, on demand:
   #   gh workflow run ci.yml -f integration=true
@@ -212,12 +218,19 @@ jobs:
 
   # Real #syntax= delegation: build the frontend image and run stock
   # `docker build -f Kernelfile`, plus a negative case (a Kernelfile the
-  # frontend must reject). Config-only (no kernel compile) so it stays ~3
-  # min; KBF_E2E_COMPILE=1 adds a real vmlinux build. On
-  # demand: gh workflow run ci.yml -f e2e=true
+  # frontend must reject). Config-only (no kernel compile) so it stays a
+  # few minutes, which is why it runs on every push to main and every
+  # same-repo PR: it is the one check that proves the image and the
+  # #syntax= path a user actually hits. KBF_E2E_COMPILE=1 adds a real
+  # vmlinux build; on demand: gh workflow run ci.yml -f e2e=true. Fork PRs
+  # skip it (self-hosted runner, registry credentials); the ci gate below
+  # accounts for that.
   e2e:
     name: docker #syntax= e2e
-    if: github.event_name == 'workflow_dispatch' && inputs.e2e
+    if: >-
+      (github.event_name == 'workflow_dispatch' && inputs.e2e)
+      || github.event_name == 'push'
+      || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
     # Namespace runner: real docker + privileged build vertices for a nested
     # #syntax= build.
     runs-on: namespace-profile-linux-amd64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,12 @@ name: release
 # holds the run until the maintainer approves it in the Actions UI: a tag
 # push alone publishes nothing.
 #
+# Nothing reaches GHCR untested. The multi-arch image is pushed to the
+# Namespace registry first, the e2e suite builds a real kernel through it
+# with stock `docker build -f Kernelfile` and boots that kernel in QEMU,
+# and only then is the same digest promoted to the GHCR tags, signed and
+# attested. A failed gate leaves GHCR untouched.
+#
 # The package is private on its first publish; flip it to public once in the
 # repository's package settings, or every anonymous `docker build` against
 # the README's ref fails to pull the frontend.
@@ -33,10 +39,10 @@ env:
 
 jobs:
   image:
-    name: publish frontend image
+    name: build, gate, publish frontend image
     runs-on: namespace-profile-linux-amd64
     environment: release
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
@@ -90,6 +96,18 @@ jobs:
           echo "args=$args" >> "$GITHUB_OUTPUT"
           echo "publishing: $args"
 
+      # Staging lives in the Namespace registry the runner is already
+      # authenticated to, so a gate failure never touches the public package.
+      - name: Resolve the staging registry (nscr.io)
+        id: staging
+        env:
+          VERSION: ${{ steps.tags.outputs.version }}
+        run: |
+          reg="${NSC_CONTAINER_REGISTRY:-}"
+          [ -z "$reg" ] && reg=$(nsc workspace describe 2>/dev/null | grep -oE 'nscr\.io/[a-z0-9]+' | head -1)
+          if [ -z "$reg" ]; then echo "::error::no nscr.io registry"; exit 1; fi
+          echo "ref=$reg/kernelbuild-buildkit-release:$VERSION-$GITHUB_RUN_ID" >> "$GITHUB_OUTPUT"
+
       - name: Log in to GHCR
         env:
           GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -107,15 +125,40 @@ jobs:
       # attestation manifests in the pushed index. NOT SLSA L3: that needs the
       # build to run inside a trusted hosted builder, and this one runs on our
       # own runners - the provenance says exactly that, which is the point.
-      - name: Build and push
+      - name: Build and push to staging
         id: build
+        env:
+          STAGING: ${{ steps.staging.outputs.ref }}
         run: |
           docker buildx build --platform linux/amd64,linux/arm64 \
-            -f Dockerfile.frontend ${{ steps.tags.outputs.args }} \
+            -f Dockerfile.frontend --tag "$STAGING" \
             --provenance=mode=max --sbom=true \
             --metadata-file metadata.json --push .
           digest=$(python3 -c "import json;print(json.load(open('metadata.json'))['containerimage.digest'])")
           echo "digest=$digest" >> "$GITHUB_OUTPUT"
+          echo "staged $STAGING@$digest"
+
+      # The gate: the exact staged image, through the path a user takes.
+      # TestE2E runs the config-only delegation, the negative case, a full
+      # vmlinux + bzImage build, and boots the result (QEMU; Firecracker
+      # when /dev/kvm is there). Roughly a kernel compile of wall time.
+      - name: Install QEMU for the boot check
+        run: sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends qemu-system-x86
+      - name: Gate on a kernel built and booted through the staged image
+        env:
+          KBF_E2E_IMAGE: ${{ steps.staging.outputs.ref }}
+          KBF_E2E_PREBUILT: "1"
+          KBF_E2E_COMPILE: "1"
+        run: go test -tags e2e -v -timeout 50m -run TestE2E .
+
+      # Promote by digest: imagetools copies the staged index, attestation
+      # manifests included, to the GHCR tags without rebuilding anything, so
+      # what was tested is byte-for-byte what is published.
+      - name: Promote the staged digest to GHCR
+        env:
+          STAGING: ${{ steps.staging.outputs.ref }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: docker buildx imagetools create ${{ steps.tags.outputs.args }} "$STAGING@$DIGEST"
 
       - name: Sign the image (keyless)
         uses: sigstore/cosign-installer@v4

--- a/docs/development.md
+++ b/docs/development.md
@@ -160,9 +160,14 @@ git push origin v0.1.0
 A stable tag publishes `:X.Y.Z`, `:X.Y`, `:X`, and `:latest`. A prerelease such
 as `v0.2.0-rc1` publishes only its exact version.
 
-The release builds amd64 and arm64 images, attaches SLSA provenance and an SPDX
-SBOM, signs the index through GitHub OIDC, and verifies the published manifests,
-attestations, and BuildKit frontend labels.
+The workflow pauses in the `release` environment until a maintainer approves
+it in the Actions UI. It then builds amd64 and arm64 images with SLSA
+provenance and an SPDX SBOM, pushes them to a staging registry, and runs the
+e2e suite against that exact image: a config-only build, a negative case, a
+full vmlinux build, and a QEMU boot of the result. Only a passing gate promotes
+the digest to the GHCR tags, signs it through GitHub OIDC, verifies the
+published manifests, attestations, and BuildKit frontend labels, and creates
+the GitHub Release.
 
 Before announcing the first release, make the GHCR package public and verify an
 anonymous pull:

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -26,7 +26,10 @@ import (
 
 // e2eImage is the #syntax= ref. On a remote builder (Namespace nsc-remote)
 // it must be a registry the builder can pull, set via KBF_E2E_IMAGE; locally
-// a --load'd tag on the docker driver suffices.
+// a --load'd tag on the docker driver suffices. KBF_E2E_PREBUILT=1 says the
+// ref already exists and must be tested as-is instead of rebuilt here: the
+// release workflow stages the exact image it is about to publish and runs
+// this suite against it before promoting it.
 func e2eImageRef() string {
 	if v := os.Getenv("KBF_E2E_IMAGE"); v != "" {
 		return v
@@ -46,6 +49,13 @@ func buildFrontendImage(t *testing.T) {
 	t.Helper()
 	if _, err := exec.LookPath("docker"); err != nil {
 		t.Skip("docker not available")
+	}
+	if os.Getenv("KBF_E2E_PREBUILT") == "1" {
+		if os.Getenv("KBF_E2E_IMAGE") == "" {
+			t.Fatal("KBF_E2E_PREBUILT=1 needs KBF_E2E_IMAGE")
+		}
+		t.Logf("using prebuilt frontend image %s", e2eImageRef())
+		return
 	}
 	root, err := os.Getwd()
 	must(t, err)


### PR DESCRIPTION
ci.yml: the e2e job (build the frontend image, push it to the Namespace
registry, run stock docker build -f Kernelfile for a config-only build
plus a negative case) now runs on every push to main and every same-repo
PR, and the ci gate requires it for those. Fork PRs still pass on the
unit job alone.

release.yml: nothing reaches GHCR untested. The multi-arch image is pushed
to the Namespace registry first; the e2e suite runs against that exact
image with KBF_E2E_PREBUILT=1 and KBF_E2E_COMPILE=1, so it builds a real
vmlinux through the #syntax= path and boots it in QEMU; only then is the
same digest promoted to the GHCR tags by imagetools, signed, attested and
released. A failed gate leaves the public package untouched.
