### PR TITLE
README badges and Codecov coverage upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,9 @@ jobs:
         arch: [amd64, arm64]
     runs-on: namespace-profile-linux-${{ matrix.arch }}
     timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write # tokenless Codecov upload
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
@@ -81,7 +84,15 @@ jobs:
       - name: go mod tidy -diff
         run: go mod tidy -diff
       - name: go test -race
-        run: go test -race ./...
+        run: go test -race -covermode=atomic -coverprofile=coverage.out ./...
+      # One upload per run; the arm64 leg exercises the same code.
+      - name: Upload coverage
+        if: matrix.arch == 'amd64'
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.out
+          use_oidc: true
+          fail_ci_if_error: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # kernelbuild-buildkit
 
+[![CI](https://github.com/emirb/kernelbuild-buildkit/actions/workflows/ci.yml/badge.svg)](https://github.com/emirb/kernelbuild-buildkit/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/emirb/kernelbuild-buildkit?include_prereleases&sort=semver)](https://github.com/emirb/kernelbuild-buildkit/releases)
+[![Go Reference](https://pkg.go.dev/badge/github.com/emirb/kernelbuild-buildkit.svg)](https://pkg.go.dev/github.com/emirb/kernelbuild-buildkit)
+[![Go Report Card](https://goreportcard.com/badge/github.com/emirb/kernelbuild-buildkit)](https://goreportcard.com/report/github.com/emirb/kernelbuild-buildkit)
+[![Coverage](https://codecov.io/gh/emirb/kernelbuild-buildkit/graph/badge.svg)](https://codecov.io/gh/emirb/kernelbuild-buildkit)
+[![License: MIT](https://img.shields.io/github/license/emirb/kernelbuild-buildkit)](LICENSE)
+
 Build Linux kernels with stock `docker build`. No local compiler, source
 checkout, or custom client is required.
 


### PR DESCRIPTION
CI, latest release, Go Reference, Go Report Card, coverage and license
badges at the top of the README. The unit job writes a coverage profile
and uploads it to Codecov through OIDC (no token), non-blocking.
