### PR TITLE
CI hygiene: concurrency, shared checks, scoped permissions, Scorecard, no GOPROXY=direct

### DIFF
--- a/.github/actions/go-checks/action.yml
+++ b/.github/actions/go-checks/action.yml
@@ -1,0 +1,48 @@
+name: Go checks
+description: >-
+  The unit-level gate: fetch modules and tools once, then gofmt, go vet,
+  go mod tidy -diff, go test -race, golangci-lint and govulncheck. Shared by
+  the self-hosted matrix and the fork-PR job so the two cannot drift.
+inputs:
+  coverage:
+    description: Write coverage.out from the test run ("true" or "false").
+    default: "false"
+runs:
+  using: composite
+  steps:
+    # Everything the checks need, fetched up front. Tools that are not
+    # actions are pinned like the actions are.
+    - name: Prepare
+      shell: bash
+      run: |
+        go mod download
+        go install golang.org/x/vuln/cmd/govulncheck@v1.7.0
+    - name: gofmt
+      shell: bash
+      run: test -z "$(gofmt -l .)"
+    - name: go vet
+      shell: bash
+      run: go vet ./...
+    - name: go mod tidy -diff
+      shell: bash
+      run: go mod tidy -diff
+    - name: go test -race
+      shell: bash
+      env:
+        COVERAGE: ${{ inputs.coverage }}
+      run: |
+        if [ "$COVERAGE" = true ]; then
+          go test -race -covermode=atomic -coverprofile=coverage.out ./...
+        else
+          go test -race ./...
+        fi
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v9
+      with:
+        # Pinned: "latest" breaks CI on linter releases with zero code
+        # change. Bump deliberately.
+        version: v2.13
+    # Blocking on purpose: a silenced security gate is worse than a red one.
+    - name: govulncheck
+      shell: bash
+      run: govulncheck ./...

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,11 +9,17 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    # A week between a version's release and its bump: the window in which
+    # a compromised release is usually noticed and pulled.
+    cooldown:
+      default-days: 7
     labels: [dependencies]
   - package-ecosystem: gomod
     directory: /
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7
     labels: [dependencies]
     groups:
       go-modules:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,12 +22,11 @@ on:
 permissions:
   contents: read
 
-# proxy.golang.org rate-limits by egress IP, and runners share theirs, so a
-# module-download burst from one run can 403 the next (the default GOPROXY
-# falls back to direct only on 404/410, never 403). Fetch from origin
-# instead; the module cache keeps warm runs from paying for it.
-env:
-  GOPROXY: direct
+# One live run per ref: a newer push to a PR cancels the run it supersedes;
+# pushes to main queue instead, so a merged result is never half-checked.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # Caching runs on Namespace cache VOLUMES, not the GitHub cache protocol:
 # GOMODCACHE and GOCACHE are mounted rather than restored from a tarball, so
@@ -54,6 +53,9 @@ jobs:
         arch: [amd64, arm64]
     runs-on: namespace-profile-linux-${{ matrix.arch }}
     timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write # tokenless Codecov upload
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
@@ -68,29 +70,17 @@ jobs:
         continue-on-error: true
         with:
           cache: go
-      # Everything the job needs, fetched once and up front: the module
-      # graph, and the tools that are not actions. Pinned, like the actions.
-      - name: Prepare
-        run: |
-          go mod download
-          go install golang.org/x/vuln/cmd/govulncheck@v1.7.0
-      - name: gofmt
-        run: test -z "$(gofmt -l .)"
-      - name: go vet
-        run: go vet ./...
-      - name: go mod tidy -diff
-        run: go mod tidy -diff
-      - name: go test -race
-        run: go test -race ./...
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+      - uses: ./.github/actions/go-checks
         with:
-          # Pinned: "latest" breaks CI on linter releases with zero code
-          # change. Bump deliberately.
-          version: v2.13
-      # Blocking on purpose: a silenced security gate is worse than a red one.
-      - name: govulncheck
-        run: govulncheck ./...
+          coverage: "true"
+      # One upload per run; the arm64 leg exercises the same code.
+      - name: Upload coverage
+        if: matrix.arch == 'amd64'
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.out
+          use_oidc: true
+          fail_ci_if_error: false
       # One arch is enough: the targets are pure-Go parsing and extraction,
       # nothing the CPU changes. arm64 is here for the native gateway build.
       - name: fuzz smoke
@@ -117,24 +107,7 @@ jobs:
       - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
-      - name: Prepare
-        run: |
-          go mod download
-          go install golang.org/x/vuln/cmd/govulncheck@v1.7.0
-      - name: gofmt
-        run: test -z "$(gofmt -l .)"
-      - name: go vet
-        run: go vet ./...
-      - name: go mod tidy -diff
-        run: go mod tidy -diff
-      - name: go test -race
-        run: go test -race ./...
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
-        with:
-          version: v2.13
-      - name: govulncheck
-        run: govulncheck ./...
+      - uses: ./.github/actions/go-checks
 
   # The one status check the main ruleset requires. Same-repo changes run
   # `unit` and `e2e`, fork PRs run `unit-fork` only; this job passes when
@@ -262,7 +235,6 @@ jobs:
           echo "resolved registry: $reg"
       - name: Run e2e (config-only + negative)
         env:
-          GOPROXY: direct
           KBF_E2E_IMAGE: ${{ steps.reg.outputs.image }}
         run: go test -tags e2e -v -timeout 20m -run TestE2E .
 
@@ -301,7 +273,6 @@ jobs:
           echo "image=$reg/kbuild-buildkit-boot:${{ github.run_id }}" >> "$GITHUB_OUTPUT"
       - name: Build a kernel and boot it
         env:
-          GOPROXY: direct
           KBF_E2E_IMAGE: ${{ steps.reg.outputs.image }}
           KBF_E2E_COMPILE: "1"
         run: go test -tags e2e -v -timeout 60m -run TestE2E .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,14 +27,15 @@ on:
   push:
     tags: ['v*']
 
-permissions:
-  contents: write # gh release create
-  packages: write
-  id-token: write # keyless cosign signing via the GitHub OIDC token
-  attestations: write # GitHub-hosted SLSA build provenance
+permissions: {}
+
+# Releases never overlap and are never cancelled: two tags pushed together
+# publish one after the other.
+concurrency:
+  group: release
+  cancel-in-progress: false
 
 env:
-  GOPROXY: direct
   IMAGE: ghcr.io/${{ github.repository }}
 
 jobs:
@@ -43,6 +44,11 @@ jobs:
     runs-on: namespace-profile-linux-amd64
     environment: release
     timeout-minutes: 60
+    permissions:
+      contents: write # gh release create
+      packages: write
+      id-token: write # keyless cosign signing via the GitHub OIDC token
+      attestations: write # GitHub-hosted SLSA build provenance
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
@@ -158,21 +164,26 @@ jobs:
         env:
           STAGING: ${{ steps.staging.outputs.ref }}
           DIGEST: ${{ steps.build.outputs.digest }}
-        run: docker buildx imagetools create ${{ steps.tags.outputs.args }} "$STAGING@$DIGEST"
+          TAG_ARGS: ${{ steps.tags.outputs.args }}
+        run: |
+          read -ra tags <<< "$TAG_ARGS"
+          docker buildx imagetools create "${tags[@]}" "$STAGING@$DIGEST"
 
       - name: Sign the image (keyless)
         uses: sigstore/cosign-installer@v4
       - name: Cosign sign + verify
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          REPO: ${{ github.repository }}
         run: |
-          digest='${{ steps.build.outputs.digest }}'
-          echo "signing $IMAGE@$digest"
-          cosign sign --yes "$IMAGE@$digest"
+          echo "signing $IMAGE@$DIGEST"
+          cosign sign --yes "$IMAGE@$DIGEST"
           # Verifying in the same job is what turns "we ran cosign" into "the
           # signature is checkable by the identity we claim".
-          cosign verify "$IMAGE@$digest" \
-            --certificate-identity-regexp "^https://github.com/${{ github.repository }}/\\.github/workflows/release\\.yml@" \
+          cosign verify "$IMAGE@$DIGEST" \
+            --certificate-identity-regexp "^https://github.com/$REPO/\\.github/workflows/release\\.yml@" \
             --certificate-oidc-issuer https://token.actions.githubusercontent.com > /dev/null
-          echo "signed and verified $IMAGE@$digest"
+          echo "signed and verified $IMAGE@$DIGEST"
 
       # The same provenance statement in the form the gh CLI verifies:
       #   gh attestation verify oci://ghcr.io/emirb/kernelbuild-buildkit:X.Y.Z \
@@ -189,8 +200,10 @@ jobs:
       # fails at solve time on the other kind of worker with "no match for
       # platform in manifest", long after the release looks green.
       - name: Verify the published manifest
+        env:
+          VERSION: ${{ steps.tags.outputs.version }}
         run: |
-          ref="$IMAGE:${{ steps.tags.outputs.version }}"
+          ref="$IMAGE:$VERSION"
           docker buildx imagetools inspect "$ref" | tee manifest.txt
           for p in linux/amd64 linux/arm64; do
             grep -q "Platform:    $p" manifest.txt || {

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,36 @@
+name: Scorecard
+
+# OpenSSF Scorecard: an automated audit of this repository's supply-chain
+# practices (token permissions, pinned dependencies, branch protection,
+# dangerous workflow patterns, ...). Results land in the Security tab as
+# code scanning alerts and on the public scorecard for the README badge.
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '23 6 * * 1' # weekly, Monday 06:23 UTC
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: scorecard analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      security-events: write # upload the SARIF to code scanning
+      id-token: write # publish_results signs the upload with the workflow identity
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: ossf/scorecard-action@v2
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+      - uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -12,7 +12,7 @@ on:
     - cron: '23 6 * * 1' # weekly, Monday 06:23 UTC
   workflow_dispatch:
 
-permissions: read-all
+permissions: {}
 
 jobs:
   analysis:
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
+      contents: read
       security-events: write # upload the SARIF to code scanning
       id-token: write # publish_results signs the upload with the workflow identity
     steps:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # kernelbuild-buildkit
 
+[![CI](https://github.com/emirb/kernelbuild-buildkit/actions/workflows/ci.yml/badge.svg)](https://github.com/emirb/kernelbuild-buildkit/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/emirb/kernelbuild-buildkit?include_prereleases&sort=semver)](https://github.com/emirb/kernelbuild-buildkit/releases)
+[![Go Reference](https://pkg.go.dev/badge/github.com/emirb/kernelbuild-buildkit.svg)](https://pkg.go.dev/github.com/emirb/kernelbuild-buildkit)
+[![Go Report Card](https://goreportcard.com/badge/github.com/emirb/kernelbuild-buildkit)](https://goreportcard.com/report/github.com/emirb/kernelbuild-buildkit)
+[![Coverage](https://codecov.io/gh/emirb/kernelbuild-buildkit/graph/badge.svg)](https://codecov.io/gh/emirb/kernelbuild-buildkit)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/emirb/kernelbuild-buildkit/badge)](https://scorecard.dev/viewer/?uri=github.com/emirb/kernelbuild-buildkit)
+[![License: MIT](https://img.shields.io/github/license/emirb/kernelbuild-buildkit)](LICENSE)
+
 Build Linux kernels with stock `docker build`. No local compiler, source
 checkout, or custom client is required.
 

--- a/go.mod
+++ b/go.mod
@@ -86,6 +86,6 @@ require (
 	golang.org/x/text v0.40.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
-	google.golang.org/grpc v1.82.1 // indirect
+	google.golang.org/grpc v1.83.1 // indirect
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -240,8 +240,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:q4lMZS6kskjT5HvCPrnnypcDPVJqT/f4nfxmkE7gryY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa h1:mZHHdPZl0dbGHCflZgAq/Q468DWVFcU2whhB2KAo8fk=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
-google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
+google.golang.org/grpc v1.83.1 h1:HIO0+BEtBP6soyqvqC8sNUjZ7bTs+0hFQuFF+RAy++Y=
+google.golang.org/grpc v1.83.1/go.mod h1:kDyl6SKsiHKt0uylY5gtn5cEjkrIOhQOGDgIc4JGwzQ=
 google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af h1:+5/Sw3GsDNlEmu7TfklWKPdQ0Ykja5VEmq2i817+jbI=
 google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
- concurrency groups: a newer push to a PR cancels the superseded run,
  pushes to main queue, releases serialize and never cancel.
- The unit checks live in one composite action used by both the
  self-hosted matrix and the fork-PR job, so the two cannot drift.
- release.yml grants its write permissions at the job level and passes
  every step output through env instead of inline expressions.
- Dependabot waits seven days after a release before bumping to it.
- OpenSSF Scorecard runs weekly and on main, publishing to the Security
  tab and the README badge. CodeQL default setup is enabled in settings.
- GOPROXY=direct is gone: it was a workaround for rate limits on a runner
  fleet this repo no longer uses, and it turned every cold-cache module
  download into minutes of git clones.
- README badges and the Codecov upload from #9 ride along, since that
  branch and this one touch the same job.
