### PR TITLE
Pin cosign-installer and scorecard-action to exact versions; drop the retired Go Report Card badge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,7 +170,7 @@ jobs:
           docker buildx imagetools create "${tags[@]}" "$STAGING@$DIGEST"
 
       - name: Sign the image (keyless)
-        uses: sigstore/cosign-installer@v4
+        uses: sigstore/cosign-installer@v4.1.2 # publishes no floating major tag
       - name: Cosign sign + verify
         env:
           DIGEST: ${{ steps.build.outputs.digest }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - uses: ossf/scorecard-action@v2
+      - uses: ossf/scorecard-action@v2.4.4 # publishes no floating major tag
         with:
           results_file: results.sarif
           results_format: sarif

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![CI](https://github.com/emirb/kernelbuild-buildkit/actions/workflows/ci.yml/badge.svg)](https://github.com/emirb/kernelbuild-buildkit/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/emirb/kernelbuild-buildkit?include_prereleases&sort=semver)](https://github.com/emirb/kernelbuild-buildkit/releases)
 [![Go Reference](https://pkg.go.dev/badge/github.com/emirb/kernelbuild-buildkit.svg)](https://pkg.go.dev/github.com/emirb/kernelbuild-buildkit)
-[![Go Report Card](https://goreportcard.com/badge/github.com/emirb/kernelbuild-buildkit)](https://goreportcard.com/report/github.com/emirb/kernelbuild-buildkit)
 [![Coverage](https://codecov.io/gh/emirb/kernelbuild-buildkit/graph/badge.svg)](https://codecov.io/gh/emirb/kernelbuild-buildkit)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/emirb/kernelbuild-buildkit/badge)](https://scorecard.dev/viewer/?uri=github.com/emirb/kernelbuild-buildkit)
 [![License: MIT](https://img.shields.io/github/license/emirb/kernelbuild-buildkit)](LICENSE)


### PR DESCRIPTION
Neither action publishes a floating major tag, so @v4 and @v2 resolved to
nothing and failed the release and Scorecard jobs at setup. Dependabot
bumps exact pins the same way.
