### PR TITLE
Scorecard: match the reference workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -3,14 +3,18 @@ name: Scorecard
 # OpenSSF Scorecard: an automated audit of this repository's supply-chain
 # practices (token permissions, pinned dependencies, branch protection,
 # dangerous workflow patterns, ...). Results land in the Security tab as
-# code scanning alerts and on the public scorecard for the README badge.
+# code scanning alerts, as a downloadable SARIF artifact, and on the public
+# scorecard behind the README badge.
+#
+# Shape follows ossf/scorecard's own workflow, and publish_results imposes
+# it: no workflow-level write permissions, no env or defaults, a GitHub-
+# hosted Ubuntu runner, and only the approved actions in this job.
 
 on:
   push:
-    branches: [main]
+    branches: [main] # only the default branch is supported
   schedule:
     - cron: '23 6 * * 1' # weekly, Monday 06:23 UTC
-  workflow_dispatch:
 
 permissions: {}
 
@@ -31,7 +35,16 @@ jobs:
         with:
           results_file: results.sarif
           results_format: sarif
+          # Replaces the Scorecard team's weekly scan of this repository with
+          # this run's result, and is what feeds the badge and the API.
           publish_results: true
-      - uses: github/codeql-action/upload-sarif@v3
+      # The raw result, readable by anyone for five days: the code scanning
+      # view is visible only to people with write access.
+      - uses: actions/upload-artifact@v7
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+      - uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
Adds the five-day SARIF artifact (readable by anyone, unlike the code
scanning view), moves upload-sarif to codeql-action v4, and drops the
experimental workflow_dispatch trigger. Publishing already works: the
first run put the repository on scorecard.dev.
