### PR TITLE
Go 1.27.1

### DIFF
--- a/.github/actions/go-checks/action.yml
+++ b/.github/actions/go-checks/action.yml
@@ -41,7 +41,7 @@ runs:
       with:
         # Pinned: "latest" breaks CI on linter releases with zero code
         # change. Bump deliberately.
-        version: v2.13
+        version: v2.13.2
     # Blocking on purpose: a silenced security gate is worse than a red one.
     - name: govulncheck
       shell: bash

--- a/docs/development.md
+++ b/docs/development.md
@@ -22,7 +22,7 @@
 
 ## Local checks
 
-The module targets Go 1.26 and is also tested with Go 1.27.
+The module targets Go 1.27; CI uses the toolchain named in `go.mod`.
 
 ```bash
 test -z "$(gofmt -l .)"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/emirb/kernelbuild-buildkit
 
-go 1.26.7
+go 1.27.1
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.45.1


### PR DESCRIPTION
go.mod moves to 1.27.1; golangci-lint pinned to v2.13.2, the first line
with Go 1.27 support. No code changes were needed.
