### PR TITLE
CI: never cancel a push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,13 @@ on:
 permissions:
   contents: read
 
-# One live run per ref: a newer push to a PR cancels the run it supersedes;
-# pushes to main queue instead, so a merged result is never half-checked.
+# Pull requests: one live run per ref, a newer push cancels the run it
+# supersedes. Pushes to main: a group per commit, so every merged commit is
+# checked in full. Sharing one group with cancel-in-progress off is not
+# enough: the group holds a single pending slot, so a second merge within a
+# couple of minutes cancels the queued run and the badge reports failure.
 concurrency:
-  group: ci-${{ github.ref }}
+  group: ci-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # Caching runs on Namespace cache VOLUMES, not the GitHub cache protocol:


### PR DESCRIPTION
The shared per-ref concurrency group holds one pending slot, so two merges
a minute apart cancelled the first run outright and the CI badge reported
failure for a commit that was never tested. Pushes to main now get a group
per commit; pull requests keep the per-ref group with cancellation.
