### PR TITLE
README: read the Scorecard badge from the current API

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Release](https://img.shields.io/github/v/release/emirb/kernelbuild-buildkit?include_prereleases&sort=semver)](https://github.com/emirb/kernelbuild-buildkit/releases)
 [![Go Reference](https://pkg.go.dev/badge/github.com/emirb/kernelbuild-buildkit.svg)](https://pkg.go.dev/github.com/emirb/kernelbuild-buildkit)
 [![Coverage](https://codecov.io/gh/emirb/kernelbuild-buildkit/graph/badge.svg)](https://codecov.io/gh/emirb/kernelbuild-buildkit)
-[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/emirb/kernelbuild-buildkit/badge)](https://scorecard.dev/viewer/?uri=github.com/emirb/kernelbuild-buildkit)
+[![OpenSSF Scorecard](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.scorecard.dev%2Fprojects%2Fgithub.com%2Femirb%2Fkernelbuild-buildkit&query=%24.score&label=openssf%20scorecard)](https://scorecard.dev/viewer/?uri=github.com/emirb/kernelbuild-buildkit)
 [![License: MIT](https://img.shields.io/github/license/emirb/kernelbuild-buildkit)](LICENSE)
 
 Build Linux kernels with stock `docker build`. No local compiler, source


### PR DESCRIPTION
The official badge URL redirects to shields.io's Scorecard integration,
which still queries the legacy host that only carries the OpenSSF team's
weekly scan of established repositories; a repository publishing its own
results is not there, so the badge rendered "invalid repo path". A
dynamic badge over api.scorecard.dev shows the published score.
