### PR TITLE
Tests for the opt layer, the gateway build path, tree preparation, configure, extraction writes, and base resolution

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -101,6 +101,14 @@ func TestStageHelper(t *testing.T) {
 			t.Fatal("want error for missing helper")
 		}
 	})
+	t.Run("default-next-to-executable", func(t *testing.T) {
+		// "" means next to argv[0]; the test binary has no kbuild-step
+		// beside it, so the error must say what to build, not just ENOENT.
+		_, err := stageHelper("")
+		if err == nil || !strings.Contains(err.Error(), "kbuild-step helper not found") {
+			t.Fatalf("default path: %v", err)
+		}
+	})
 	t.Run("not-elf", func(t *testing.T) {
 		_, err := stageHelper(write(t, []byte("#!/bin/sh\necho no\n")))
 		if err == nil || !strings.Contains(err.Error(), "linux/amd64") {

--- a/cmd/kbuild-frontend/build_test.go
+++ b/cmd/kbuild-frontend/build_test.go
@@ -1,0 +1,197 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/client/llb/sourceresolver"
+	gwclient "github.com/moby/buildkit/frontend/gateway/client"
+	"github.com/moby/buildkit/frontend/subrequests"
+	"github.com/moby/buildkit/solver/pb"
+	digest "github.com/opencontainers/go-digest"
+	fstypes "github.com/tonistiigi/fsutil/types"
+
+	kbuild "github.com/emirb/kernelbuild-buildkit"
+)
+
+// fakeGW is the slice of the gateway the frontend touches: build opts, local
+// solves (the Kernelfile fetch and the context probe), image resolution, and
+// the graph solve. Files and missing paths are declared per test.
+type fakeGW struct {
+	gwclient.Client
+	opts    map[string]string
+	files   map[string][]byte // the "dockerfile" local
+	missing map[string]bool   // context paths StatFile reports absent
+	solves  []gwclient.SolveRequest
+}
+
+func (f *fakeGW) BuildOpts() gwclient.BuildOpts { return gwclient.BuildOpts{Opts: f.opts} }
+
+func (f *fakeGW) Solve(_ context.Context, req gwclient.SolveRequest) (*gwclient.Result, error) {
+	f.solves = append(f.solves, req)
+	res := gwclient.NewResult()
+	res.SetRef(&fakeRef{gw: f})
+	return res, nil
+}
+
+func (f *fakeGW) ResolveImageConfig(_ context.Context, ref string, _ sourceresolver.Opt) (string, digest.Digest, []byte, error) {
+	return ref, digest.FromString(ref), nil, nil
+}
+
+type fakeRef struct {
+	gwclient.Reference
+	gw *fakeGW
+}
+
+func (r *fakeRef) ReadFile(_ context.Context, req gwclient.ReadRequest) ([]byte, error) {
+	b, ok := r.gw.files[req.Filename]
+	if !ok {
+		return nil, fmt.Errorf("%s: no such file", req.Filename)
+	}
+	return b, nil
+}
+
+func (r *fakeRef) StatFile(_ context.Context, req gwclient.StatRequest) (*fstypes.Stat, error) {
+	if r.gw.missing[req.Path] {
+		return nil, errors.New("no such file or directory")
+	}
+	return &fstypes.Stat{Path: req.Path}, nil
+}
+
+// compileEnv returns the compile exec's env from the last graph solve.
+func compileEnv(t *testing.T, gw *fakeGW) map[string]string {
+	t.Helper()
+	for _, req := range slices.Backward(gw.solves) {
+		def := req.Definition
+		if def == nil {
+			continue
+		}
+		for _, dt := range def.Def {
+			var op pb.Op
+			if err := op.Unmarshal(dt); err != nil {
+				t.Fatal(err)
+			}
+			e, ok := op.Op.(*pb.Op_Exec)
+			if !ok || len(e.Exec.Meta.Args) == 0 || e.Exec.Meta.Args[0] != kbuild.HelperPath {
+				continue
+			}
+			env := map[string]string{}
+			for _, kv := range e.Exec.Meta.Env {
+				k, v, _ := strings.Cut(kv, "=")
+				env[k] = v
+			}
+			return env
+		}
+	}
+	t.Fatal("no compile exec was solved")
+	return nil
+}
+
+// TestBuildDelegatesKernelfile: the #syntax= path end to end: the Kernelfile
+// is read from the dockerfile local, parsed, layered with opts, checked
+// against the context, and solved as the compile graph.
+func TestBuildDelegatesKernelfile(t *testing.T) {
+	gw := &fakeGW{
+		opts: map[string]string{
+			"source":   "ghcr.io/example/frontend:v1",
+			"filename": "Kernelfile",
+			"targets":  "config",
+		},
+		files: map[string][]byte{"Kernelfile": []byte("KERNEL 6.19.1\nCONFIG guest.config\nEPOCH 1700000000\n")},
+	}
+	if _, err := build(context.Background(), gw); err != nil {
+		t.Fatal(err)
+	}
+	env := compileEnv(t, gw)
+	if env["SRC_URL"] != kbuild.SourceURLFor("6.19.1") || env["SRC_SHA256"] != "" {
+		t.Errorf("KERNEL line not honored: SRC_URL=%q SRC_SHA256=%q", env["SRC_URL"], env["SRC_SHA256"])
+	}
+	if env["SOURCE_DATE_EPOCH"] != "1700000000" {
+		t.Errorf("EPOCH = %q", env["SOURCE_DATE_EPOCH"])
+	}
+	if env["TARGETS"] != "config" {
+		t.Errorf("--opt targets did not layer over the Kernelfile: TARGETS=%q", env["TARGETS"])
+	}
+}
+
+// TestBuildFailsOnUnreadableKernelfile: the dockerfile local exists but the
+// named file cannot be read; falling through to defaults would build a
+// kernel the user never asked for.
+func TestBuildFailsOnUnreadableKernelfile(t *testing.T) {
+	gw := &fakeGW{opts: map[string]string{"source": "ghcr.io/example/frontend:v1", "filename": "Kernelfile"}}
+	_, err := build(context.Background(), gw)
+	if err == nil || !strings.Contains(err.Error(), "Kernelfile") {
+		t.Fatalf("missing Kernelfile: err = %v", err)
+	}
+	if len(gw.solves) > 1 {
+		t.Error("compile graph solved despite the unreadable Kernelfile")
+	}
+}
+
+func TestBuildRejectsUnknownKernelfileKey(t *testing.T) {
+	gw := &fakeGW{
+		opts:  map[string]string{"source": "ghcr.io/example/frontend:v1", "filename": "Kernelfile"},
+		files: map[string][]byte{"Kernelfile": []byte("FROBNICATE yes\n")},
+	}
+	_, err := build(context.Background(), gw)
+	if err == nil || !strings.Contains(err.Error(), "unknown key") {
+		t.Fatalf("unknown key: err = %v", err)
+	}
+}
+
+// TestBuildRequiresAHelperImage: a direct gateway.v0 invocation must carry
+// opt source= or helper-ref, or there is no kbuild-step to mount.
+func TestBuildRequiresAHelperImage(t *testing.T) {
+	gw := &fakeGW{opts: map[string]string{"kernel-version": "6.19.1"}}
+	_, err := build(context.Background(), gw)
+	if err == nil || !strings.Contains(err.Error(), "helper") {
+		t.Fatalf("no helper: err = %v", err)
+	}
+}
+
+// TestBuildReportsMissingContextFile: a CONFIG the context lacks is named
+// before any graph is solved.
+func TestBuildReportsMissingContextFile(t *testing.T) {
+	gw := &fakeGW{
+		opts:    map[string]string{"source": "ghcr.io/example/frontend:v1", "config": "guest.config"},
+		missing: map[string]bool{"guest.config": true},
+	}
+	_, err := build(context.Background(), gw)
+	if err == nil || !strings.Contains(err.Error(), "CONFIG guest.config") {
+		t.Fatalf("missing config: err = %v", err)
+	}
+}
+
+// TestBuildAnswersSubrequests: docker build --print=... must be answered
+// with a report, never with a kernel build; an unknown subrequest is an
+// error, not a build either.
+func TestBuildAnswersSubrequests(t *testing.T) {
+	gw := &fakeGW{opts: map[string]string{"source": "ghcr.io/example/frontend:v1", "requestid": subrequests.RequestSubrequestsDescribe}}
+	res, err := build(context.Background(), gw)
+	if err != nil || res == nil || len(res.Metadata["result.json"]) == 0 {
+		t.Fatalf("describe: res=%v err=%v", res, err)
+	}
+	if len(gw.solves) != 0 {
+		t.Error("describe started a solve")
+	}
+	gw = &fakeGW{opts: map[string]string{"source": "ghcr.io/example/frontend:v1", "requestid": "frontend.outline"}}
+	if _, err := build(context.Background(), gw); err == nil {
+		t.Error("unsupported subrequest accepted")
+	}
+	if len(gw.solves) != 0 {
+		t.Error("unsupported subrequest started a solve")
+	}
+}
+
+// TestBuildRecoversFromPanic: a frontend must never die with a bare exit
+// code; a panic becomes a readable error. A nil client panics on BuildOpts.
+func TestBuildRecoversFromPanic(t *testing.T) {
+	_, err := build(context.Background(), nil)
+	if err == nil || !strings.Contains(err.Error(), "panic") {
+		t.Fatalf("panic not converted to an error: %v", err)
+	}
+}

--- a/cmd/kbuild-frontend/main.go
+++ b/cmd/kbuild-frontend/main.go
@@ -200,11 +200,8 @@ func applyOpts(opts map[string]string, spec *kbuild.Spec) error {
 	if v := opts["base"]; v != "" {
 		spec.Base = v
 	}
-	switch opts["toolchain-ready"] {
-	case "true":
-		spec.ToolchainReady = true
-	case "false":
-		spec.ToolchainReady = false
+	if err := optBool(opts, "toolchain-ready", &spec.ToolchainReady); err != nil {
+		return err
 	}
 	if v := opts["arch"]; v != "" {
 		spec.Arch = v
@@ -246,13 +243,12 @@ func applyOpts(opts map[string]string, spec *kbuild.Spec) error {
 		spec.Arch = arch
 	}
 	if v := opts["targets"]; v != "" {
-		spec.Targets = strings.Split(v, ",")
+		// Commas or spaces, like the Kernelfile: "vmlinux, image" is what
+		// people type, and " image" is not a target.
+		spec.Targets = strings.FieldsFunc(v, func(r rune) bool { return r == ',' || r == ' ' || r == '\t' })
 	}
-	switch opts["apply-patches"] {
-	case "true":
-		spec.ApplyPatches = true
-	case "false":
-		spec.ApplyPatches = false
+	if err := optBool(opts, "apply-patches", &spec.ApplyPatches); err != nil {
+		return err
 	}
 	if _, ok := opts["no-cache"]; ok {
 		// `docker build --no-cache` sends this key with an empty value (a
@@ -261,12 +257,28 @@ func applyOpts(opts map[string]string, spec *kbuild.Spec) error {
 		// user explicitly asked to re-run.
 		spec.IgnoreCache = true
 	}
-	if opts["seed-push"] == "true" {
-		// The seed destination arrives via the seed_cfg secret (cache-
-		// neutral); this opt forces the compile vertex to execute so the
-		// push actually happens instead of being cache-elided, and tells the
-		// step a push was requested (a missing secret then fails loudly).
-		spec.SeedPush = true
+	// The seed destination arrives via the seed_cfg secret (cache-neutral);
+	// seed-push forces the compile vertex to execute so the push actually
+	// happens instead of being cache-elided, and tells the step a push was
+	// requested (a missing secret then fails loudly).
+	if err := optBool(opts, "seed-push", &spec.SeedPush); err != nil {
+		return err
+	}
+	return nil
+}
+
+// optBool reads a true/false opt into dst, leaving dst alone when the opt is
+// absent. Any other spelling is an error: "apply-patches=1" silently
+// building an unpatched kernel is worse than a rejected build.
+func optBool(opts map[string]string, key string, dst *bool) error {
+	switch v := opts[key]; v {
+	case "":
+	case "true":
+		*dst = true
+	case "false":
+		*dst = false
+	default:
+		return fmt.Errorf("opt %s=%q: want true or false", key, v)
 	}
 	return nil
 }

--- a/cmd/kbuild-frontend/opts_test.go
+++ b/cmd/kbuild-frontend/opts_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"reflect"
+	"strings"
 	"testing"
 
 	kbuild "github.com/emirb/kernelbuild-buildkit"
@@ -34,5 +36,109 @@ func TestApplyOptsProxies(t *testing.T) {
 	spec := kbuild.DefaultSpec()
 	if err := applyOpts(map[string]string{"platform": "linux/amd64,linux/arm64"}, &spec); err == nil {
 		t.Error("multi-platform accepted by applyOpts")
+	}
+}
+
+// TestApplyOptsEveryKey: each --opt key lands on exactly the Spec field it
+// names, so a typo in the mapping cannot silently build a different kernel.
+func TestApplyOptsEveryKey(t *testing.T) {
+	spec := kbuild.DefaultSpec()
+	err := applyOpts(map[string]string{
+		"kernel-version":     "6.19.1",
+		"source-sha256":      strings.Repeat("ab", 32),
+		"source-date-epoch":  "1700000000",
+		"config":             "guest.config",
+		"expect":             "guest.expect",
+		"base-make":          "x86_64_defconfig kvm_guest.config",
+		"proxy-ca":           "ca.crt",
+		"helper-ref":         "ghcr.io/x/helper:v1",
+		"src-name":           "linux-6.19.1.tar.xz",
+		"base":               "docker.io/tuxmake/x86_64_gcc:latest",
+		"toolchain-ready":    "true",
+		"arch":               "arm64",
+		"cross-compile":      "aarch64-linux-gnu-",
+		"force-network-mode": "host",
+		"targets":            "vmlinux,image",
+		"apply-patches":      "true",
+		"no-cache":           "",
+		"seed-push":          "true",
+	}, &spec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := kbuild.Spec{
+		KernelVersion: "6.19.1", SourceURL: kbuild.SourceURLFor("6.19.1"), SourceSHA256: strings.Repeat("ab", 32),
+		SourceDateEpoch: "1700000000", ConfigName: "guest.config", ExpectName: "guest.expect",
+		BaseMake: "x86_64_defconfig kvm_guest.config", ProxyCAFile: "ca.crt", HelperRef: "ghcr.io/x/helper:v1",
+		SourceLocalName: "linux-6.19.1.tar.xz", Base: "docker.io/tuxmake/x86_64_gcc:latest", ToolchainReady: true,
+		Arch: "arm64", CrossCompile: "aarch64-linux-gnu-", NetworkHost: true, Targets: []string{"vmlinux", "image"},
+		ApplyPatches: true, IgnoreCache: true, SeedPush: true, SeedPrefix: "kbuild-seed",
+	}
+	if !reflect.DeepEqual(spec, want) {
+		t.Errorf("applyOpts mapped\n got %+v\nwant %+v", spec, want)
+	}
+}
+
+// TestApplyOptsRejectsMalformedBooleans: "apply-patches=1" must not build an
+// unpatched kernel and report success, and "seed-push=yes" must not run a
+// build that publishes nothing. Anything but true/false is an error.
+func TestApplyOptsRejectsMalformedBooleans(t *testing.T) {
+	for _, tc := range []struct{ key, val string }{
+		{"toolchain-ready", "yes"},
+		{"apply-patches", "1"},
+		{"seed-push", "on"},
+	} {
+		spec := kbuild.DefaultSpec()
+		if err := applyOpts(map[string]string{tc.key: tc.val}, &spec); err == nil || !strings.Contains(err.Error(), tc.key) {
+			t.Errorf("%s=%s: err = %v, want an error naming the key", tc.key, tc.val, err)
+		}
+	}
+	for _, val := range []string{"true", "false"} {
+		spec := kbuild.DefaultSpec()
+		if err := applyOpts(map[string]string{"apply-patches": val}, &spec); err != nil {
+			t.Errorf("apply-patches=%s rejected: %v", val, err)
+		}
+	}
+}
+
+// TestApplyOptsTargetsTolerateSpaces: the Kernelfile accepts "vmlinux, image";
+// the opt form must too, instead of failing Validate on " image".
+func TestApplyOptsTargetsTolerateSpaces(t *testing.T) {
+	spec := kbuild.DefaultSpec()
+	if err := applyOpts(map[string]string{"targets": "vmlinux, image config"}, &spec); err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"vmlinux", "image", "config"}; !reflect.DeepEqual(spec.Targets, want) {
+		t.Errorf("Targets = %q, want %q", spec.Targets, want)
+	}
+	if err := spec.Validate(); err != nil {
+		t.Errorf("Validate after opt targets: %v", err)
+	}
+}
+
+// TestApplyOptsSourceOverridesClearThePin: a new kernel version or URL
+// invalidates the default tarball's sha256; an explicit sha256 wins.
+func TestApplyOptsSourceOverridesClearThePin(t *testing.T) {
+	spec := kbuild.DefaultSpec()
+	if err := applyOpts(map[string]string{"kernel-version": "6.19.1"}, &spec); err != nil {
+		t.Fatal(err)
+	}
+	if spec.SourceSHA256 != "" || spec.SourceURL != kbuild.SourceURLFor("6.19.1") {
+		t.Errorf("version override kept the default pin: %q %q", spec.SourceSHA256, spec.SourceURL)
+	}
+	spec = kbuild.DefaultSpec()
+	if err := applyOpts(map[string]string{"source-url": "https://mirror.example/linux-6.18.20.tar.xz"}, &spec); err != nil {
+		t.Fatal(err)
+	}
+	if spec.SourceSHA256 != "" {
+		t.Error("source-url override kept the default pin")
+	}
+	spec = kbuild.DefaultSpec()
+	sha := strings.Repeat("cd", 32)
+	if err := applyOpts(map[string]string{"kernel-version": "6.19.1", "source-sha256": sha}, &spec); err != nil {
+		t.Fatal(err)
+	}
+	if spec.SourceSHA256 != sha {
+		t.Errorf("explicit sha256 lost: %q", spec.SourceSHA256)
 	}
 }

--- a/cmd/kbuild-step/main.go
+++ b/cmd/kbuild-step/main.go
@@ -268,7 +268,7 @@ func prepareTree(ctx context.Context, seed *seedCfg) error {
 	}
 	if !treePresent() && seed != nil {
 		t := time.Now()
-		n, found, err := seedPull(ctx, seed)
+		n, found, err := pullSeed(ctx, seed)
 		switch {
 		case err != nil:
 			return fmt.Errorf("seed pull: %w", err)
@@ -1271,6 +1271,10 @@ func s3Client(ctx context.Context, c *seedCfg) (*s3.Client, string, error) {
 	})
 	return cl, bucket, nil
 }
+
+// pullSeed is what prepareTree calls to hydrate a cold mount: seedPull in
+// the binary, a fake in the tests (the S3 client has no seam of its own).
+var pullSeed = seedPull
 
 // seedPull downloads and extracts the seed. found is false when the seed
 // object does not exist yet.

--- a/cmd/kbuild-step/tree_test.go
+++ b/cmd/kbuild-step/tree_test.go
@@ -1,0 +1,282 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// fakeSeed installs a pullSeed that materializes the given files into the
+// build dir (a seed tarball's effect) and reports found/err. A nil files map
+// with found=true still counts as a pull: the caller's stamp check decides.
+func fakeSeed(t *testing.T, found bool, err error, files map[string]string) {
+	t.Helper()
+	old := pullSeed
+	pullSeed = func(context.Context, *seedCfg) (int64, bool, error) {
+		if err != nil || !found {
+			return 0, found, err
+		}
+		var n int64
+		for name, content := range files {
+			if err := os.WriteFile(filepath.Join(buildDir, name), []byte(content), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			n += int64(len(content))
+		}
+		return n, true, nil
+	}
+	t.Cleanup(func() { pullSeed = old })
+}
+
+// sourceServer serves one tarball whose sha the test pins through SRC_ID and
+// SRC_SHA256; returns the Makefile content it carries.
+func sourceServer(t *testing.T) (makefile string) {
+	t.Helper()
+	makefile = "from-tarball:\n"
+	tarball, sum := gzTarSHA(t, [3]string{"linux-9.9/Makefile", "f", makefile})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(tarball)
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("APPLY_PATCHES", "0")
+	t.Setenv("SRC_LOCAL", "")
+	t.Setenv("SRC_URL", srv.URL+"/linux-9.9.tar.gz")
+	t.Setenv("SRC_ID", sum)
+	t.Setenv("SRC_SHA256", sum)
+	return makefile
+}
+
+func readFile(t *testing.T, name string) string {
+	t.Helper()
+	b, err := os.ReadFile(name)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+// TestPrepareTreeSeed covers the cold-mount decisions in prepareTree: a seed
+// whose stamp matches this build is adopted as-is, a seed with a foreign
+// stamp is discarded and the tarball extracted instead, an absent seed falls
+// through to extraction, and a transport error is fatal.
+func TestPrepareTreeSeed(t *testing.T) {
+	seed := &seedCfg{url: "https://h/b", key: "k"}
+
+	t.Run("matching-stamp-is-adopted", func(t *testing.T) {
+		build, _, _ := withDirs(t)
+		t.Chdir(build)
+		sourceServer(t)
+		want, err := stampWant()
+		if err != nil {
+			t.Fatal(err)
+		}
+		fakeSeed(t, true, nil, map[string]string{"Makefile": "from-seed:\n", ".kbf-stamp.seed": want})
+		if err := prepareTree(context.Background(), seed); err != nil {
+			t.Fatal(err)
+		}
+		if got := readFile(t, "Makefile"); got != "from-seed:\n" {
+			t.Fatalf("Makefile = %q, want the seed's (the tarball must not have been extracted over it)", got)
+		}
+		if readStamp() != want {
+			t.Errorf("stamp = %q, want %q", readStamp(), want)
+		}
+		if _, err := os.Stat(".kbf-stamp.seed"); !os.IsNotExist(err) {
+			t.Error("quarantined seed stamp left behind")
+		}
+	})
+
+	t.Run("foreign-stamp-is-discarded", func(t *testing.T) {
+		build, _, _ := withDirs(t)
+		t.Chdir(build)
+		makefile := sourceServer(t)
+		fakeSeed(t, true, nil, map[string]string{"Makefile": "from-seed:\n", "stale.o": "x", ".kbf-stamp.seed": "src=OTHER patches=none"})
+		if err := prepareTree(context.Background(), seed); err != nil {
+			t.Fatal(err)
+		}
+		if got := readFile(t, "Makefile"); got != makefile {
+			t.Fatalf("Makefile = %q, want the tarball's %q", got, makefile)
+		}
+		if _, err := os.Stat("stale.o"); !os.IsNotExist(err) {
+			t.Error("foreign seed's object survived the discard")
+		}
+		want, _ := stampWant()
+		if readStamp() != want {
+			t.Errorf("stamp = %q, want %q", readStamp(), want)
+		}
+	})
+
+	t.Run("absent-seed-extracts", func(t *testing.T) {
+		build, _, _ := withDirs(t)
+		t.Chdir(build)
+		makefile := sourceServer(t)
+		fakeSeed(t, false, nil, nil)
+		if err := prepareTree(context.Background(), seed); err != nil {
+			t.Fatal(err)
+		}
+		if got := readFile(t, "Makefile"); got != makefile {
+			t.Fatalf("Makefile = %q, want the tarball's", got)
+		}
+	})
+
+	t.Run("transport-error-is-fatal", func(t *testing.T) {
+		build, _, _ := withDirs(t)
+		t.Chdir(build)
+		sourceServer(t)
+		fakeSeed(t, false, errors.New("connection reset"), nil)
+		err := prepareTree(context.Background(), seed)
+		if err == nil || !strings.Contains(err.Error(), "seed pull") {
+			t.Fatalf("seed error: %v", err)
+		}
+	})
+}
+
+// TestPrepareTreeWarmAndStale: a warm tree with a matching stamp is reused
+// without touching the source at all, and a mount holding stale objects but
+// no Makefile (an extract killed midway) is cleared before hydrating.
+func TestPrepareTreeWarmAndStale(t *testing.T) {
+	t.Run("warm-tree-needs-no-source", func(t *testing.T) {
+		build, _, _ := withDirs(t)
+		t.Chdir(build)
+		t.Setenv("APPLY_PATCHES", "0")
+		t.Setenv("SRC_LOCAL", "")
+		t.Setenv("SRC_URL", "https://unreachable.invalid/linux.tar.gz")
+		t.Setenv("SRC_ID", "warm")
+		t.Setenv("SRC_SHA256", "")
+		want, _ := stampWant()
+		if err := os.WriteFile("Makefile", []byte("warm:\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(".kbf-stamp", []byte(want), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := prepareTree(context.Background(), nil); err != nil {
+			t.Fatalf("warm tree reached for the source: %v", err)
+		}
+		if readFile(t, "Makefile") != "warm:\n" {
+			t.Error("warm tree was replaced")
+		}
+	})
+
+	t.Run("stale-objects-cleared-before-extract", func(t *testing.T) {
+		build, _, _ := withDirs(t)
+		t.Chdir(build)
+		makefile := sourceServer(t)
+		if err := os.WriteFile("stale.o", []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := prepareTree(context.Background(), nil); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := os.Stat("stale.o"); !os.IsNotExist(err) {
+			t.Error("stale object survived into the fresh tree")
+		}
+		if readFile(t, "Makefile") != makefile {
+			t.Error("tree not extracted")
+		}
+	})
+}
+
+// loggingMake puts a `make` on PATH that records its argv, one line per
+// invocation, and creates .config when asked for a defconfig-style target.
+func loggingMake(t *testing.T) (logPath string) {
+	t.Helper()
+	dir := t.TempDir()
+	logPath = filepath.Join(dir, "make.log")
+	script := "#!/bin/sh\necho \"$*\" >> \"$FAKE_MAKE_LOG\"\n" +
+		"if [ -n \"$FAKE_MAKE_FAIL\" ]; then exit 1; fi\n" +
+		"case \"$1\" in olddefconfig) : ;; *defconfig|tinyconfig) printf 'CONFIG_BASE=y\\n' > .config ;; esac\nexit 0\n"
+	if err := os.WriteFile(filepath.Join(dir, "make"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("FAKE_MAKE_LOG", logPath)
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return logPath
+}
+
+// TestConfigureBaseMake: with BASE_MAKE the tree's own config targets run
+// first (with ARCH/CROSS_COMPILE), the context config is appended as a
+// fragment, olddefconfig follows, and an identical input then skips all of it.
+func TestConfigureBaseMake(t *testing.T) {
+	logPath := loggingMake(t)
+	build, _, _ := withDirs(t)
+	t.Chdir(build)
+	t.Setenv("BASE_MAKE", "x86_64_defconfig kvm_guest.config")
+	t.Setenv("KARCH", "x86_64")
+	t.Setenv("CROSS_COMPILE", "x86_64-linux-gnu-")
+	withConfig(t, "CONFIG_A=y\n")
+
+	if err := configure(); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := readFile(t, ".config"), "CONFIG_BASE=y\n\nCONFIG_A=y\n"; got != want {
+		t.Errorf(".config = %q, want base config plus fragment %q", got, want)
+	}
+	calls := strings.Split(strings.TrimSpace(readFile(t, logPath)), "\n")
+	if len(calls) != 2 {
+		t.Fatalf("make calls = %q, want base-make then olddefconfig", calls)
+	}
+	if !strings.HasPrefix(calls[0], "x86_64_defconfig kvm_guest.config") || !strings.Contains(calls[0], "ARCH=x86_64") || !strings.Contains(calls[0], "CROSS_COMPILE=x86_64-linux-gnu-") {
+		t.Errorf("base-make call = %q", calls[0])
+	}
+	if !strings.HasPrefix(calls[1], "olddefconfig") || !strings.Contains(calls[1], "ARCH=x86_64") {
+		t.Errorf("olddefconfig call = %q", calls[1])
+	}
+
+	// Same fragment, same base: nothing runs.
+	if err := configure(); err != nil {
+		t.Fatal(err)
+	}
+	if again := strings.Split(strings.TrimSpace(readFile(t, logPath)), "\n"); len(again) != 2 {
+		t.Errorf("unchanged config re-ran make: %q", again)
+	}
+
+	// Same fragment over a different base is a different config: it re-runs.
+	t.Setenv("BASE_MAKE", "x86_64_defconfig")
+	if err := configure(); err != nil {
+		t.Fatal(err)
+	}
+	if again := strings.Split(strings.TrimSpace(readFile(t, logPath)), "\n"); len(again) != 4 {
+		t.Errorf("base change did not re-run make: %q", again)
+	}
+
+	// A failing base target is reported as such, and the skip marker is not
+	// left pointing at the new input.
+	t.Setenv("FAKE_MAKE_FAIL", "1")
+	withConfig(t, "CONFIG_B=y\n")
+	err := configure()
+	if err == nil || !strings.Contains(err.Error(), "base-make") {
+		t.Fatalf("base-make failure: %v", err)
+	}
+	if _, err := os.Stat(".kbf-config-src"); !os.IsNotExist(err) {
+		t.Error("skip marker survived a failed configure")
+	}
+}
+
+// TestConfigureEmptyFragmentOverBase: an empty context config over BASE_MAKE
+// appends nothing, so .config is exactly what the base target produced.
+func TestConfigureEmptyFragmentOverBase(t *testing.T) {
+	loggingMake(t)
+	build, _, _ := withDirs(t)
+	t.Chdir(build)
+	t.Setenv("BASE_MAKE", "tinyconfig")
+	t.Setenv("KARCH", "")
+	t.Setenv("CROSS_COMPILE", "")
+	withConfig(t, "# nothing\n\n")
+	if err := configure(); err != nil {
+		t.Fatal(err)
+	}
+	// "# nothing" is not blank, so it is appended; only whitespace-only input skips.
+	withConfig(t, "  \n")
+	t.Setenv("BASE_MAKE", "defconfig")
+	if err := configure(); err != nil {
+		t.Fatal(err)
+	}
+	if got := readFile(t, ".config"); got != "CONFIG_BASE=y\n" {
+		t.Errorf(".config = %q, want the bare base config", got)
+	}
+}

--- a/cmd/kbuild-step/write_test.go
+++ b/cmd/kbuild-step/write_test.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"archive/tar"
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+type failingReader struct{}
+
+func (failingReader) Read([]byte) (int, error) { return 0, errors.New("stream cut") }
+
+func openRoot(t *testing.T) (*os.Root, string) {
+	t.Helper()
+	dir := t.TempDir()
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = root.Close() })
+	return root, dir
+}
+
+// TestWriteEntryErrors: every failure on the way to a written file is
+// reported, never swallowed: a parent that is a regular file, a target that
+// is a non-empty directory, and a body that fails mid-stream.
+func TestWriteEntryErrors(t *testing.T) {
+	hdr := &tar.Header{Mode: 0o644, ModTime: time.Unix(1700000000, 0)}
+
+	t.Run("parent-is-a-file", func(t *testing.T) {
+		root, dir := openRoot(t)
+		if err := os.WriteFile(filepath.Join(dir, "f"), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := writeEntry(root, "f/child", strings.NewReader("y"), hdr); err == nil {
+			t.Fatal("wrote through a regular file as a directory")
+		}
+	})
+	t.Run("target-is-a-populated-directory", func(t *testing.T) {
+		root, dir := openRoot(t)
+		if err := os.MkdirAll(filepath.Join(dir, "d", "inner"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := writeEntry(root, "d", strings.NewReader("y"), hdr); err == nil {
+			t.Fatal("replaced a populated directory with a file")
+		}
+		if _, err := os.Stat(filepath.Join(dir, "d", "inner")); err != nil {
+			t.Error("the directory's contents were removed")
+		}
+	})
+	t.Run("body-fails-mid-stream", func(t *testing.T) {
+		root, dir := openRoot(t)
+		err := writeEntry(root, "a/b.txt", failingReader{}, hdr)
+		if err == nil || !strings.Contains(err.Error(), "stream cut") {
+			t.Fatalf("read error not propagated: %v", err)
+		}
+		// The partial file exists (tar semantics leave it to the caller's
+		// nuke) but must not claim the header's mode or mtime as if complete.
+		if fi, err := os.Stat(filepath.Join(dir, "a", "b.txt")); err == nil && fi.ModTime().Equal(hdr.ModTime) {
+			t.Error("mtime restored on a partial file")
+		}
+	})
+	t.Run("success-restores-mode-and-mtime", func(t *testing.T) {
+		root, dir := openRoot(t)
+		exec := &tar.Header{Mode: 0o755, ModTime: time.Unix(1700000000, 0)}
+		if err := writeEntry(root, "bin/tool", bytes.NewReader([]byte("#!/bin/sh\n")), exec); err != nil {
+			t.Fatal(err)
+		}
+		fi, err := os.Stat(filepath.Join(dir, "bin", "tool"))
+		if err != nil || fi.Mode().Perm() != 0o755 || !fi.ModTime().Equal(exec.ModTime) {
+			t.Errorf("mode/mtime = %v %v, %v", fi.Mode(), fi.ModTime(), err)
+		}
+	})
+}
+
+// TestWriteFileBytesErrors: the pooled writer has the same contract.
+func TestWriteFileBytesErrors(t *testing.T) {
+	mtime := time.Unix(1700000000, 0)
+	t.Run("parent-is-a-file", func(t *testing.T) {
+		root, dir := openRoot(t)
+		if err := os.WriteFile(filepath.Join(dir, "f"), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := writeFileBytes(root, "f/child", 0o644, mtime, []byte("y")); err == nil {
+			t.Fatal("wrote through a regular file as a directory")
+		}
+	})
+	t.Run("target-is-a-populated-directory", func(t *testing.T) {
+		root, dir := openRoot(t)
+		if err := os.MkdirAll(filepath.Join(dir, "d", "inner"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := writeFileBytes(root, "d", 0o644, mtime, []byte("y")); err == nil {
+			t.Fatal("replaced a populated directory with a file")
+		}
+	})
+	t.Run("replaces-a-symlink-instead-of-following-it", func(t *testing.T) {
+		root, dir := openRoot(t)
+		if err := os.WriteFile(filepath.Join(dir, "victim"), []byte("untouched"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink("victim", filepath.Join(dir, "link")); err != nil {
+			t.Fatal(err)
+		}
+		if err := writeFileBytes(root, "link", 0o644, mtime, []byte("payload")); err != nil {
+			t.Fatal(err)
+		}
+		if b, _ := os.ReadFile(filepath.Join(dir, "victim")); string(b) != "untouched" {
+			t.Fatalf("wrote through the symlink: victim = %q", b)
+		}
+		if fi, err := os.Lstat(filepath.Join(dir, "link")); err != nil || fi.Mode()&os.ModeSymlink != 0 {
+			t.Error("link was not replaced by a regular file")
+		}
+	})
+}

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -89,15 +89,23 @@ func TestS3CacheURLRegion(t *testing.T) {
 // interface), which is what we want from a test double.
 type fakeGW struct {
 	gwclient.Client
-	dgst     digest.Digest
-	resolved []string
-	solves   []gwclient.SolveRequest
-	readDir  func(path string) ([]*fstypes.Stat, error)
-	statFile func(path string) error // nil: every file exists
+	dgst       digest.Digest
+	resolved   []string
+	solves     []gwclient.SolveRequest
+	readDir    func(path string) ([]*fstypes.Stat, error)
+	statFile   func(path string) error // nil: every file exists
+	resolveErr error                   // returned by ResolveImageConfig when set
+	resolveRef string                  // ref ResolveImageConfig hands back when set (else the input)
 }
 
 func (f *fakeGW) ResolveImageConfig(_ context.Context, ref string, _ sourceresolver.Opt) (string, digest.Digest, []byte, error) {
 	f.resolved = append(f.resolved, ref)
+	if f.resolveErr != nil {
+		return "", "", nil, f.resolveErr
+	}
+	if f.resolveRef != "" {
+		ref = f.resolveRef
+	}
 	return ref, f.dgst, nil, nil
 }
 
@@ -296,5 +304,41 @@ func TestGatewaySolveChecksContextFiles(t *testing.T) {
 	}
 	if graphSolves(t, ok) != 1 {
 		t.Error("all files present but the compile graph was not solved")
+	}
+}
+
+// TestResolveBase: a resolver failure and a resolver that returns no digest
+// are both errors naming the base; a returned ref that already carries a
+// digest is re-pinned on its tag part, not doubled.
+func TestResolveBase(t *testing.T) {
+	spec := baseSpec()
+	spec.Base = "docker.io/tuxmake/x86_64_gcc"
+	spec.ToolchainReady = true
+
+	failing := &fakeGW{resolveErr: errors.New("manifest unknown")}
+	_, err := GatewaySolve(context.Background(), failing, spec, GatewayOpts{})
+	if err == nil || !strings.Contains(err.Error(), "resolve base image") || !strings.Contains(err.Error(), "manifest unknown") {
+		t.Errorf("resolver error: %v", err)
+	}
+
+	nodigest := &fakeGW{}
+	_, err = GatewaySolve(context.Background(), nodigest, spec, GatewayOpts{})
+	if err == nil || !strings.Contains(err.Error(), "no digest") {
+		t.Errorf("empty digest: %v", err)
+	}
+
+	dgst := digest.FromString("img")
+	suffixed := &fakeGW{dgst: dgst, resolveRef: "docker.io/tuxmake/x86_64_gcc@" + dgst.String()}
+	if _, err := GatewaySolve(context.Background(), suffixed, spec, GatewayOpts{}); err != nil {
+		t.Fatal(err)
+	}
+	var pinned string
+	for _, op := range opsOf(t, suffixed.solves[len(suffixed.solves)-1].Definition) {
+		if s, ok := op.Op.(*pb.Op_Source); ok && strings.Contains(s.Source.Identifier, "tuxmake") {
+			pinned = s.Source.Identifier
+		}
+	}
+	if want := "docker-image://docker.io/tuxmake/x86_64_gcc@" + dgst.String(); pinned != want {
+		t.Errorf("base identifier = %q, want %q (digest suffix must not be doubled)", pinned, want)
 	}
 }


### PR DESCRIPTION
Written red first where the code was wrong, green after the fix:
- applyOpts accepted any spelling of a boolean opt; "apply-patches=1"
  built an unpatched kernel and reported success. Now only true/false.
- --opt targets split on commas only, so "vmlinux, image" failed
  Validate on " image"; it now splits like the Kernelfile does.

The rest cover code that was right but unexercised, each verified by a
mutation that the new test catches: prepareTree's seed adoption, foreign-
seed discard, absent-seed extraction, transport errors, warm reuse and
stale-object clearing (through a pullSeed seam); configure's BASE_MAKE
prelude, ARCH/CROSS_COMPILE threading, unchanged-input skip and marker
invalidation on failure; writeEntry and writeFileBytes error paths; the
frontend's build and readKernelfile through a fake gateway, including
subrequests, the panic guard and missing context files; resolveBase's
error, no-digest and digest-suffix branches; stageHelper's default path.

Coverage: frontend 47% -> 92%, step 57% -> 62%, root 78% -> 79%.
