### PR TITLE
Pin every action to a commit SHA

### DIFF
--- a/.github/actions/go-checks/action.yml
+++ b/.github/actions/go-checks/action.yml
@@ -37,7 +37,7 @@ runs:
           go test -race ./...
         fi
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v9
+      uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
       with:
         # Pinned: "latest" breaks CI on linter releases with zero code
         # change. Bump deliberately.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,5 @@
 # Keeps the actions and the Go module graph current. Actions are pinned to
-# major tags, so Dependabot only opens a PR when a major version lands.
+# commit SHAs with the version in a comment; Dependabot bumps both.
 # Go modules are grouped into one monthly PR; govulncheck is a blocking CI
 # gate, so a CVE still shows up on main immediately, and that PR is how it
 # turns green again.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,13 +57,13 @@ jobs:
     runs-on: namespace-profile-linux-${{ matrix.arch }}
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-go@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache: false
       # Go module + build cache on a Namespace cache volume (see the note above).
-      - uses: namespacelabs/nscloud-cache-action@v1
+      - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
         # Non-fatal on purpose: the action hard-errors when the runner profile
         # has Caching disabled, and a missing cache is a slow build, not a
         # wrong one.
@@ -78,7 +78,7 @@ jobs:
       # non-blocking so a missing or rotated token never fails a build.
       - name: Upload coverage
         if: matrix.arch == 'amd64'
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: coverage.out
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -105,8 +105,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-go@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
       - uses: ./.github/actions/go-checks
@@ -152,13 +152,13 @@ jobs:
     runs-on: namespace-profile-linux-amd64
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-go@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache: false
       # Go module + build cache on a Namespace cache volume (see the note above).
-      - uses: namespacelabs/nscloud-cache-action@v1
+      - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
         # Non-fatal on purpose: the action hard-errors when the runner profile
         # has Caching disabled, and a missing cache is a slow build, not a
         # wrong one. Enable Caching on the profile to get the volume back
@@ -211,13 +211,13 @@ jobs:
     runs-on: namespace-profile-linux-amd64
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-go@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache: false
       # Go module + build cache on a Namespace cache volume (see the note above).
-      - uses: namespacelabs/nscloud-cache-action@v1
+      - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
         # Non-fatal on purpose: the action hard-errors when the runner profile
         # has Caching disabled, and a missing cache is a slow build, not a
         # wrong one. Enable Caching on the profile to get the volume back
@@ -251,13 +251,13 @@ jobs:
     runs-on: namespace-profile-linux-amd64
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-go@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache: false
       # Go module + build cache on a Namespace cache volume (see the note above).
-      - uses: namespacelabs/nscloud-cache-action@v1
+      - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
         continue-on-error: true
         with:
           cache: go

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,13 +50,13 @@ jobs:
       id-token: write # keyless cosign signing via the GitHub OIDC token
       attestations: write # GitHub-hosted SLSA build provenance
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-go@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache: false
       # Go module + build cache on a Namespace cache volume (see ci.yml).
-      - uses: namespacelabs/nscloud-cache-action@v1
+      - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
         # Non-fatal on purpose: the action hard-errors when the runner profile
         # has Caching disabled, and a missing cache is a slow build, not a
         # wrong one. Enable Caching on the profile to get the volume back
@@ -170,7 +170,7 @@ jobs:
           docker buildx imagetools create "${tags[@]}" "$STAGING@$DIGEST"
 
       - name: Sign the image (keyless)
-        uses: sigstore/cosign-installer@v4.1.2 # publishes no floating major tag
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
       - name: Cosign sign + verify
         env:
           DIGEST: ${{ steps.build.outputs.digest }}
@@ -190,7 +190,7 @@ jobs:
       #     --repo emirb/kernelbuild-buildkit
       # No key material, no cosign install, no certificate flags for the user.
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-name: ${{ env.IMAGE }}
           subject-digest: ${{ steps.build.outputs.digest }}
@@ -253,7 +253,7 @@ jobs:
       # of this workflow at this commit.
       - name: Attest release assets
         id: attest-assets
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-path: dist/release/*
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -28,10 +28,10 @@ jobs:
       security-events: write # upload the SARIF to code scanning
       id-token: write # publish_results signs the upload with the workflow identity
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: ossf/scorecard-action@v2.4.4 # publishes no floating major tag
+      - uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
         with:
           results_file: results.sarif
           results_format: sarif
@@ -40,11 +40,11 @@ jobs:
           publish_results: true
       # The raw result, readable by anyone for five days: the code scanning
       # view is visible only to people with write access.
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
-      - uses: github/codeql-action/upload-sarif@v4
+      - uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
Scorecard's Pinned-Dependencies check flags each action on a mutable
tag, once per line; a tag can be moved, a commit cannot. Every reference
now carries the full SHA with the version it corresponds to in a comment,
which Dependabot keeps current.
